### PR TITLE
Add start-up logging

### DIFF
--- a/WebService/Database/DatabaseClient.cs
+++ b/WebService/Database/DatabaseClient.cs
@@ -1,17 +1,24 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 
 namespace WebService.Database
 {
     public class DatabaseClient : IDisposable
     {
+        private readonly ILogger _logger;
         private readonly SqlConnection _connection;
 
-        public DatabaseClient(DatabaseSettings settings, string username, string password)
+        public DatabaseClient(ILoggerFactory loggerFactory, DatabaseSettings settings, string username, string password)
         {
+            _logger = loggerFactory.CreateLogger("Database");
+            _logger.LogInformation($"connecting to '{ settings.DataSource }' database with username { username }: started");
+
             _connection = new SqlConnection(BuildConnectionString(settings, username, password));
             _connection.Open();
+
+            _logger.LogInformation($"connecting to '{ settings.DataSource }' database with username { username }: done");
         }
 
         public IEnumerable<Product> GetProducts()

--- a/WebService/Program.cs
+++ b/WebService/Program.cs
@@ -1,19 +1,24 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace WebService
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
-        }
+            var loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.UseStartup<Startup>();
-            });
+            var host = Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(builder =>
+                {
+                    builder.UseStartup(context => new Startup(loggerFactory));
+                })
+                .Build();
+
+            await host.RunAsync();
+        }
     }
 }

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using VaultSharp.V1.SecretsEngines;
 using WebService.Controllers;
 using WebService.Database;
@@ -12,12 +13,20 @@ namespace WebService
 {
     public class Startup
     {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public Startup(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             VaultWrapper vault = new VaultWrapper
             (
+                _loggerFactory,
                 new VaultWrapperSettings
                 {
                     Address                 = GetEnvironmentVariableOrThrow("VAULT_ADDRESS"),
@@ -33,6 +42,7 @@ namespace WebService
 
             DatabaseClient database = new DatabaseClient
             (
+                _loggerFactory,
                 new DatabaseSettings
                 {
                     DataSource        = GetEnvironmentVariableOrThrow("DATABASE_DATA_SOURCE"),
@@ -78,7 +88,7 @@ namespace WebService
 
             if (String.IsNullOrEmpty(value))
             {
-                throw new ApplicationException($"The required environment variable '{ variable }' is not set");
+                throw new ApplicationException($"the required environment variable '{ variable }' is not set");
             }
 
             return value;


### PR DESCRIPTION
# Description

Add logging to `Vault.cs` and `DatabaseClient.cs` to demonstrate the start-up sequence.

Fixes: VAULT-4680

## Type of change

- [x] New feature (non-breaking change that adds a new functionality)

# How Has This Been Tested?

```
$ docker logs hello-vault-dotnet-app-1
info: Vault[0]
      logging in to vault @ http://vault-server:8200 with approle role id demo-web-app: started
info: Vault[0]
      logging in to vault @ http://vault-server:8200 with approle role id demo-web-app: done
info: Vault[0]
      getting temporary database credentials from vault: started
info: Vault[0]
      getting temporary database credentials from vault: done
info: Database[0]
      connecting to 'tcp:database,1433' database with username v-approle-dev-readonly-e3SIlbOGNJlhWVacWeyX-1641253357: started
info: Database[0]
      connecting to 'tcp:database,1433' database with username v-approle-dev-readonly-e3SIlbOGNJlhWVacWeyX-1641253357: done
```
