### PR TITLE
Install global exception handler for API controllers

### DIFF
--- a/WebService/Controllers/ProductsController.cs
+++ b/WebService/Controllers/ProductsController.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using WebService.Database;
-using WebService.Vault;
 
 namespace WebService.Controllers
 {

--- a/WebService/Vault/VaultWrapper.cs
+++ b/WebService/Vault/VaultWrapper.cs
@@ -42,8 +42,7 @@ namespace WebService.Vault
 
             // We can't reuse the default VaultClient instance for unwrapping because
             // it needs to be intialized with a different TokenAuthMethodInfo
-            IVaultClient vaultClientForUnwrapping = new VaultClient
-            (
+            IVaultClient vaultClientForUnwrapping = new VaultClient(
                 new VaultClientSettings(settings.Address, new TokenAuthMethodInfo(vaultToken: wrappingToken))
             );
 
@@ -56,14 +55,12 @@ namespace WebService.Vault
                         .Result.Data[ "secret_id" ]
                             .ToString();
 
-            AppRoleAuthMethodInfo appRoleAuth = new AppRoleAuthMethodInfo
-            (
+            AppRoleAuthMethodInfo appRoleAuth = new AppRoleAuthMethodInfo(
                 roleId: settings.AppRoleAuthRoleId,
                 secretId: appRoleAuthSecretId
             );
 
-            IVaultClient client = new VaultClient
-            (
+            IVaultClient client = new VaultClient(
                 new VaultClientSettings(settings.Address, appRoleAuth)
             );
 
@@ -76,8 +73,7 @@ namespace WebService.Vault
         {
             _logger.LogInformation("getting secret api key from vault: started");
 
-            Secret<SecretData> secret = _client.V1.Secrets.KeyValue.V2.ReadSecretAsync
-            (
+            Secret<SecretData> secret = _client.V1.Secrets.KeyValue.V2.ReadSecretAsync(
                 // vault path within kv-v2/ (e.g. "api-key", not "kv-v2/api-key")
                 path: _settings.ApiKeyPath
             ).Result;
@@ -93,8 +89,7 @@ namespace WebService.Vault
         {
             _logger.LogInformation("getting temporary database credentials from vault: started");
 
-            Secret<UsernamePasswordCredentials> dynamicDatabaseCredentials = _client.V1.Secrets.Database.GetCredentialsAsync
-            (
+            Secret<UsernamePasswordCredentials> dynamicDatabaseCredentials = _client.V1.Secrets.Database.GetCredentialsAsync(
                 // vault path within database/roles/ (e.g. "dev-readonly", not "database/roles/dev-readonly")
                 roleName: _settings.DatabaseCredentialsRole
             ).Result;


### PR DESCRIPTION
# Description

Currently, if an exception is thrown in one of the API Controllers, it would not be propagated to the caller. The caller would simply get a `500` back with no explanation.

This change will ensure that the caller gets back the exception's error type & message (JSON formatted).

Fixes: VAULT-4757

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Change the query in DatabaseClient.cs:

```diff
- const string query = "SELECT * FROM [example].[dbo].[products]";
+ const string query = "SELECT typo FROM [example].[dbo].[products]";
```

```sh
 curl -s -X GET --header "Content-Length: 0" http://localhost/api/Products | jq
```
```json
{
  "error": "System.Data.SqlClient.SqlException",
  "message": "Invalid column name 'typo'."
}
```
